### PR TITLE
Improve fail error message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,11 @@ program
 
     try {
       const res = await cancel({ ...command })
-      json = await res.json()
+      try {
+        json = await res.json();
+      } catch (error) {
+        throw new Error(`Failed to parse response body as JSON:\n\n${await res.text()}`)
+      }
 
       if (json.error) {
         throw new CancelError(json.error.message)

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ program
     try {
       const res = await cancel({ ...command })
       try {
-        json = await res.json();
+        json = await res.json()
       } catch (error) {
         throw new Error(`Failed to parse response body as JSON:\n\n${await res.text()}`)
       }


### PR DESCRIPTION
We have seen cases where the CLI returns a "Failed to parse response body as JSON" message.
This change allows knowing more. 

Related to https://github.com/mui-org/material-ui/pull/23623.