### PR TITLE
Fix error handling on upload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ program
 
     try {
       const res = await cancel({ ...command })
-      const text = await res.text();
+      const text = await res.text()
       try {
         json = JSON.parse(text)
       } catch (error) {

--- a/src/index.js
+++ b/src/index.js
@@ -86,10 +86,11 @@ program
 
     try {
       const res = await cancel({ ...command })
+      const text = await res.text();
       try {
-        json = await res.json()
+        json = JSON.parse(text)
       } catch (error) {
-        throw new Error(`Failed to parse response body as JSON:\n\n${await res.text()}`)
+        throw new Error(`${res.status}: Failed to parse response body as JSON:\n\n${text}`)
       }
 
       if (json.error) {


### PR DESCRIPTION
If `.json()` failed then the body is already used and we can't flush it again e.g. by using `.text()`. So just flush it once and then manually pipe it to JSON.parse or the error handler.

Previous failure: https://app.circleci.com/pipelines/github/mui-org/material-ui/28253/workflows/bf0933ce-ae1a-447e-975c-94305cad4b3a/jobs/199676