### PR TITLE
Add a `compareCommit` param when creating build

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -14,6 +14,12 @@ const config = convict({
     default: '',
     env: 'ARGOS_COMMIT',
   },
+  compareCommit: {
+    doc: 'Git commit to compare to',
+    format: String,
+    default: '',
+    env: 'ARGOS_COMPARE_COMMIT',
+  },
   branch: {
     doc: 'Git branch',
     format: String,

--- a/src/upload.js
+++ b/src/upload.js
@@ -18,6 +18,7 @@ async function upload(options) {
     token: tokenOption,
     branch: branchOption,
     commit: commitOption,
+    compareCommit: compareCommitOption,
     externalBuildId: externalBuildIdOption,
     buildName: buildNameOption,
     batchCount: batchCountOption,
@@ -31,6 +32,7 @@ async function upload(options) {
   }
   const branch = branchOption || config.get('branch') || environment.branch
   const commit = commitOption || config.get('commit') || environment.commit
+  const compareCommit = compareCommitOption || config.get('compareCommit') || environment.compareCommit
   const externalBuildId =
     externalBuildIdOption ||
     config.get('externalBuildId') ||
@@ -73,6 +75,9 @@ async function upload(options) {
 
   displayInfo(`using \`${branch}\` as branch`)
   displayInfo(`using \`${commit}\` as commit`)
+  if (compareCommit) {
+    displayInfo(`using \`${compareCommit}\` as a comparison`)
+  }
 
   const screenshots = await readScreenshots({ cwd: directory, ignore })
 
@@ -91,6 +96,7 @@ async function upload(options) {
       name,
       branch,
       commit,
+      compareCommit,
       token,
       externalBuildId,
       batchCount,


### PR DESCRIPTION
Hey !

We'd like to compare to the `merge-base` instead of the baselineBranch, to avoid having argos screenshots diffs that don't belong to your PR but were merged in the baselineBranch the meantime.

As the Github API doesn't provide a way to get the `merge-base` (issue opened on the github community [here](https://github.community/t/please-expose-git-merge-base-is-ancestor-as-an-api/14021/2)) we can't do this directly in argos using Octokit, so we need to find a way to send it as a param to argos.

I think this might be the optimal way as it also allows to compare to basically anything if needed